### PR TITLE
fix: mobile nav button is now on left, mobile menu appears in centre

### DIFF
--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -20,9 +20,9 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="relative">
+    <nav className="md:relative ">
       {/* Hamburger button (visible on small screens) */}
-      <div className="md:hidden">
+      <div className="md:hidden absolute right-6 top-5">
         <button
           onClick={toggleMenu}
           className="text-white focus:outline-none"
@@ -35,7 +35,7 @@ export default function Navbar() {
       <ul
         className={`${
           isMenuOpen ? "block" : "hidden"
-        } absolute top-full right-0 w-full bg-transparent md:justify-center md:flex md:gap-[10vw] list-none md:static text-center`}
+        } absolute h-full left-0 w-full bg-transparent md:justify-center md:flex md:gap-[10vw] list-none md:static text-center mt-10 md:mt-0`}
       >
         {menuLinks.map((menuLink) => (
           <li


### PR DESCRIPTION
<img width="423" alt="Screenshot 2024-11-29 at 20 47 30" src="https://github.com/user-attachments/assets/6336ada1-4c1a-4067-bd28-1aa5afbe13e9">

<img width="420" alt="Screenshot 2024-11-29 at 20 47 23" src="https://github.com/user-attachments/assets/0200cb76-fe52-40fe-aae8-644fb55e3d54">

![image](https://github.com/user-attachments/assets/3a52bb97-bbe8-4388-9db6-7730c2fd465f)


